### PR TITLE
Add meta files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Racket package stuff
+compiled/

--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,4 @@
+#lang info
+
+(define collection "csc151")
+

--- a/main.rkt
+++ b/main.rkt
@@ -1,0 +1,21 @@
+#lang racket
+
+;;; File:
+;;;   csc151/main.rkt
+;;; Summary:
+;;;   A combination of all procedures defined in the csc151 collection.
+;;; Author:
+;;;   Zander Otavka
+
+(require "square.rkt")
+(require "lists.rkt")
+(require "misc.rkt")
+(require "hop.rkt")
+(require "numbers.rkt")
+
+(provide
+  (all-from-out "square.rkt")
+  (all-from-out "lists.rkt")
+  (all-from-out "misc.rkt")
+  (all-from-out "hop.rkt")
+  (all-from-out "numbers.rkt"))


### PR DESCRIPTION
Add:
* `.gitignore` since racket made some generated code in `compiled/` when I did `raco pkg install`.
* `info.rkt` to declare the collection name as `csc151` so we don't have to rely on collection name inference (`info.rkt` is the racket collection manifest file).
* `main.rkt` to re-export all the files in this collection.  Now, students can just `(require csc151)` and get everything (`main.rkt` is the racket collection root file).